### PR TITLE
style: refactor scripts to follow lint suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 .venv
 .pytest_cache/
 __pycache__
-.vscode

--- a/.vscode/extension.json
+++ b/.vscode/extension.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "ms-python.black-formatter",
+    "ms-python.isort",
+    "ms-python.pylint",
+    "ms-python.vscode-pylance",
+    "ms-python.python"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+  "files.exclude": {
+    "**/__pycache__": true
+  },
+
+  "python.linting.pylintEnabled": true,
+  "python.linting.enabled": true,
+
+  "python.analysis.diagnosticMode": "workspace",
+  "python.analysis.typeCheckingMode": "strict",
+
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.formatOnType": true,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": true
+    }
+  }
+}

--- a/models.py
+++ b/models.py
@@ -1,17 +1,23 @@
-# pylint: disable=R0913
-
-'''
-Models for the Resume API. Each class is related to
-'''
-
 from dataclasses import dataclass
 
 
 @dataclass
 class Experience:
-    '''
-    Experience Class
-    '''
+    """
+    Summary
+    -------
+    dataclass for experiences schema
+
+    Attributes
+    ----------
+    title (str): title
+    company (str): company
+    start_date (str): start date
+    end_date (str): end date
+    description (str): description
+    logo (str): logo
+    """
+
     title: str
     company: str
     start_date: str
@@ -22,9 +28,21 @@ class Experience:
 
 @dataclass
 class Education:
-    '''
-    Education Class
-    '''
+    """
+    Summary
+    -------
+    dataclass for educations schema
+
+    Attributes
+    ----------
+    course (str): course name
+    school (str): school name
+    start_date (str): start date
+    end_date (str): end date
+    grade (str): grade
+    logo (str): logo
+    """
+
     course: str
     school: str
     start_date: str
@@ -35,9 +53,18 @@ class Education:
 
 @dataclass
 class Skill:
-    '''
-    Skill Class
-    '''
+    """
+    Summary
+    -------
+    dataclass for skills schema
+
+    Attributes
+    ----------
+    name (str): skill name
+    proficiency (str): skill proficiency
+    logo (str): logo
+    """
+
     name: str
     proficiency: str
     logo: str

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -1,8 +1,4 @@
-'''
-Tests in Pytest
-'''
 from app import app
-
 
 # def test_client():
 #     '''
@@ -15,8 +11,8 @@ from app import app
 
 # def test_experience():
 #     '''
-#     Add a new experience and then get all experiences. 
-    
+#     Add a new experience and then get all experiences.
+
 #     Check that it returns the new experience in that list
 #     '''
 #     example_experience = {
@@ -36,8 +32,8 @@ from app import app
 
 # def test_education():
 #     '''
-#     Add a new education and then get all educations. 
-    
+#     Add a new education and then get all educations.
+
 #     Check that it returns the new education in that list
 #     '''
 #     example_education = {
@@ -57,8 +53,8 @@ from app import app
 
 # def test_skill():
 #     '''
-#     Add a new skill and then get all skills. 
-    
+#     Add a new skill and then get all skills.
+
 #     Check that it returns the new skill in that list
 #     '''
 #     example_skill = {
@@ -74,40 +70,57 @@ from app import app
 #     assert response.json[item_id] == example_skill
 
 
-'''
-Makes request to add a new experience and checks if the received payload have all required fileds with valid formats
-'''
 def test_add_experience():
-    response = app.test_client().post('/resume/experience', json={
-        "title": "Software Developer",
-        "company": "A Cool Company",
-        "start_date": "June 2022",
-        "end_date": "October 2024",
-        "description": "Writing Python Code",
-        "logo": "example-logo.png"
-    })
+    """
+    Summary
+    -------
+    makes request to add a new experience and checks if the received payload have all required fileds with valid formats
+    """
+    response = app.test_client().post(
+        "/resume/experience",
+        json={
+            "title": "Software Developer",
+            "company": "A Cool Company",
+            "start_date": "June 2022",
+            "end_date": "October 2024",
+            "description": "Writing Python Code",
+            "logo": "example-logo.png",
+        },
+    )
     print(response.json)
     assert response.status_code == 201
-    
-    
+
+
 def test_add_education():
-    response = app.test_client().post('/resume/education', json={
-        "course": "Computer Science",
-        "school": "University of Tech",
-        "start_date": "September 2019",
-        "end_date": "July 2022",
-        "grade": "A+",
-        "logo": "example-logo.png"
-    })
+    """
+    Summary
+    -------
+    makes request to add a new education and checks if the received payload have all required fileds with valid formats
+    """
+    response = app.test_client().post(
+        "/resume/education",
+        json={
+            "course": "Computer Science",
+            "school": "University of Tech",
+            "start_date": "September 2019",
+            "end_date": "July 2022",
+            "grade": "A+",
+            "logo": "example-logo.png",
+        },
+    )
     print(response.json)
     assert response.status_code == 201
 
 
 def test_add_skill():
-    response = app.test_client().post('/resume/skill', json={
-        "name": "Python",
-        "proficiency": "15%",
-        "logo": "example-logo.png"
-    })
+    """
+    Summary
+    -------
+    makes request to add a new skill and checks if the received payload have all required fileds with valid formats
+    """
+    response = app.test_client().post(
+        "/resume/skill",
+        json={"name": "Python", "proficiency": "15%", "logo": "example-logo.png"},
+    )
     print(response.json)
     assert response.status_code == 201

--- a/utils.py
+++ b/utils.py
@@ -1,60 +1,112 @@
 from datetime import datetime
+from typing import Any
 
-'''
-validate_date_string
-🍀 `vaidate_date_string` takes a date string as input.
-✅ It attempts to parse the date string using the strptime method from datetime module
-✅ The [%B %Y] directives are used to match date's full month name and year respectively.
-✅ It returns True if the date string format is valid, False otherwise.
 
-'''
-def validate_date_string(date_string):
+def validate_date_string(date_string: str) -> bool:
+    """
+    Summary
+    -------
+    🍀 `vaidate_date_string` takes a date string as input.
+    ✅ It attempts to parse the date string using the strptime method from datetime module
+    ✅ The [%B %Y] directives are used to match date's full month name and year respectively.
+    ✅ It returns True if the date string format is valid, False otherwise.
+
+    Parameters
+    ----------
+    date_string (str): date string
+
+    Returns
+    -------
+    valid (bool): True if the date string format is valid, False otherwise.
+    """
     if date_string.lower() in ["present", "now", "current", "till date", "till now"]:
         return True
+
     try:
         datetime.strptime(date_string, "%B %Y")
         return True
+
     except ValueError:
         return False
-'''
-validate_request
-🍀 `validate_request` takes a payload and a list of required fields as input.
-✅ It iterates over the list of required fields and checks if each field is present in the payload.
-✅ It returns True if all the required fields are present in the payload, False otherwise.
-'''
-def validate_request(payload, required_fields) -> bool:
-    for field in required_fields:
-        if field not in payload:
-            return False
-    return True
 
 
-'''
-validate_proifciency
-🍀 `validate_proficiency` takes a proficiency string as input.
-✅ It checks if the proficiency string ends with the `%` character.
-✅ It attempts to convert the proficiency string to an integer.
-✅ It returns True if the proficiency string is a valid integer between 0 and 100, False otherwise.
-'''
-def validate_proficiency(proficiency)-> bool:
-    if proficiency.endswith('%'):
-        proficiency_value = proficiency[:-1]
-        try:
-            proficiency_value = int(proficiency_value)
-            if proficiency_value >= 0 and proficiency_value <= 100:
-                return True
-        except ValueError:
-            pass
-    return False
+def validate_request(payload: dict[str, Any], required_fields: list[str]) -> bool:
+    """
+    Summary
+    -------
+    🍀 `validate_request` takes a payload and a list of required fields as input.
+    ✅ It iterates over the list of required fields and checks if each field is present in the payload.
+    ✅ It returns True if all the required fields are present in the payload, False otherwise.
 
-'''
-validate_grade
-🍀 `validate_grade` takes a grade string as input.
-✅ It checks if the grade string is present in the list of valid grades.
-✅ It returns True if the grade string is valid, False otherwise.
-'''
-def validate_grade(grade):
-    valid_grades = ["A+", "A", "A-", "B+", "B", "B-", "C+", "C", "C-", "D+", "D", "D-", "F"]
-    if grade.upper() in valid_grades:
-        return True
-    return False
+    Parameters
+    ----------
+    payload (dict[str, Any]): payload
+    required_fields (list[str]): list of required fields
+
+    Returns
+    -------
+    valid (bool): True if all the required fields are present in the payload, False otherwise.
+    """
+    return all(field in payload for field in required_fields)
+
+
+def validate_proficiency(proficiency: str) -> bool:
+    """
+    Summary
+    -------
+    🍀 `validate_proficiency` takes a proficiency string as input.
+    ✅ It checks if the proficiency string ends with the `%` character.
+    ✅ It attempts to convert the proficiency string to an integer.
+    ✅ It returns True if the proficiency string is a valid integer between 0 and 100, False otherwise.
+
+    Parameters
+    ----------
+    proficiency (str): proficiency string
+
+    Returns
+    -------
+    valid (bool): True if the proficiency string is a valid integer between 0 and 100, False otherwise.
+    """
+    if not proficiency.endswith("%"):
+        return False
+
+    try:
+        proficiency_value = int(proficiency[:-1])
+
+    except ValueError:
+        return False
+
+    return 0 <= proficiency_value <= 100
+
+
+def validate_grade(grade: str) -> bool:
+    """
+    Summary
+    -------
+    🍀 `validate_grade` takes a grade string as input.
+    ✅ It checks if the grade string is present in the list of valid grades.
+    ✅ It returns True if the grade string is valid, False otherwise.
+
+    Parameters
+    ----------
+    grade (str): grade string
+
+    Returns
+    -------
+    valid (bool): True if the grade string is a valid grade, False otherwise.
+    """
+    return grade.upper() in [
+        "A+",
+        "A",
+        "A-",
+        "B+",
+        "B",
+        "B-",
+        "C+",
+        "C",
+        "C-",
+        "D+",
+        "D",
+        "D-",
+        "F",
+    ]


### PR DESCRIPTION
## Summary

All scripts except `app.py` now follows the `Pylint` and `Pyright` ruleset. I did not refactor `app.py` because there are numerous logical errors introduced in the prior PRs. This will be addressed in another PR to keep things atomic. 

I have also taken the liberty to introduce a config file for our collaborators that are using VSCode as their editors. The config file will recommend them the appropriate extensions and set some QoL defaults to streamline their adjustment to `Pylint` and `Pyright`.  